### PR TITLE
Use Consumer<GenericObject> in order to prevent errors if the topic is not present or without a schema

### DIFF
--- a/producer-v3-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarProducerV3Tests.java
+++ b/producer-v3-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarProducerV3Tests.java
@@ -52,7 +52,7 @@ public class PulsarProducerV3Tests {
     ).asCompatibleSubstituteFor("cassandra");
 
     public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(
-            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest")
+            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest-272")
     ).asCompatibleSubstituteFor("pulsar");
 
     private static Network testNetwork;

--- a/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarProducerV4Tests.java
+++ b/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarProducerV4Tests.java
@@ -55,7 +55,7 @@ public class PulsarProducerV4Tests {
 
     public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(
             Optional.ofNullable(System.getenv("PULSAR_IMAGE"))
-                    .orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest")
+                    .orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest-272")
     ).asCompatibleSubstituteFor("pulsar");
 
     private static Network testNetwork;

--- a/source-pulsar/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
+++ b/source-pulsar/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
@@ -35,6 +35,7 @@ import io.vavr.Tuple3;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -65,7 +66,7 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
 
     CassandraSourceConnectorConfig config;
     CassandraClient cassandraClient;
-    Consumer<KeyValue<GenericRecord, MutationValue>> consumer = null;
+    Consumer<GenericObject> consumer = null;
 
     String dirtyTopicName;
     Converter mutationKeyConverter;
@@ -80,12 +81,8 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
 
     MutationCache<String> mutationCache;
 
-    Schema<KeyValue<GenericRecord, MutationValue>> eventsSchema = Schema.KeyValue(
-            Schema.AUTO_CONSUME(),
-            Schema.AVRO(MutationValue.class),
-            KeyValueEncodingType.SEPARATED);
-
     @Override
+    @SuppressWarnings("unchecked")
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         Map<String, String> processorConfig = ConfigUtil.flatString(config);
         this.config = new CassandraSourceConnectorConfig(processorConfig);
@@ -128,7 +125,7 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
         }
 
         this.dirtyTopicName = this.config.getEventsTopic();
-        ConsumerBuilder<KeyValue<GenericRecord, MutationValue>> consumerBuilder = sourceContext.newConsumerBuilder(eventsSchema)
+        ConsumerBuilder<?> consumerBuilder = sourceContext.newConsumerBuilder(Schema.AUTO_CONSUME())
                 .consumerName("CDC Consumer")
                 .topic(dirtyTopicName)
                 .subscriptionName(this.config.getEventsSubscriptionName())
@@ -136,7 +133,7 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
                 .subscriptionMode(SubscriptionMode.Durable)
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .keySharedPolicy(KeySharedPolicy.autoSplitHashRange());
-        this.consumer = consumerBuilder.subscribe();
+        this.consumer = (Consumer<GenericObject>) consumerBuilder.subscribe();
 
         this.mutationCache = new MutationCache<>(
                 this.config.getCacheMaxDigests(),
@@ -146,6 +143,12 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
         log.debug("Starting source connector topic={} subscription={}",
                 dirtyTopicName,
                 this.config.getEventsSubscriptionName());
+    }
+
+    private static MutationValue convertToMutationValue(GenericRecord record) {
+        return new MutationValue((String) record.getField("md5Digest"),
+                (UUID) record.getField("nodeId"),
+                (String[]) record.getField("columns"));
     }
 
     synchronized void setValueConverterAndQuery(KeyspaceMetadata ksm, TableMetadata tableMetadata) {
@@ -203,10 +206,10 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
     public Record<GenericRecord> read() throws Exception {
         log.debug("reading from topic={}", dirtyTopicName);
         while (true) {
-            final Message<KeyValue<GenericRecord, MutationValue>> msg = consumer.receive();
-            final KeyValue<GenericRecord, MutationValue> kv = msg.getValue();
+            final Message<GenericObject> msg = consumer.receive();
+            final KeyValue<GenericRecord, GenericRecord> kv = (KeyValue<GenericRecord, GenericRecord>) msg.getValue().getNativeObject();
             final GenericRecord mutationKey = kv.getKey();
-            final MutationValue mutationValue = kv.getValue();
+            final MutationValue mutationValue = convertToMutationValue(kv.getValue());
 
             log.debug("Message from producer={} msgId={} key={} value={}\n",
                     msg.getProducerName(), msg.getMessageId(), kv.getKey(), kv.getValue());
@@ -264,8 +267,8 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
         }
     }
 
-    <T> java.util.function.Consumer<T> acknowledgeConsumer(final Consumer<KeyValue<GenericRecord, MutationValue>> consumer,
-                                                           final Message<KeyValue<GenericRecord, MutationValue>> message) {
+    <T> java.util.function.Consumer<T> acknowledgeConsumer(final Consumer<GenericObject> consumer,
+                                                           final Message<GenericObject> message) {
         return new java.util.function.Consumer<T>() {
             @Override
             public void accept(T t) {
@@ -275,8 +278,8 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
     }
 
     // Acknowledge the message so that it can be deleted by the message broker
-    void acknowledge(final Consumer<KeyValue<GenericRecord, MutationValue>> consumer,
-                     final Message<KeyValue<GenericRecord, MutationValue>> message) {
+    void acknowledge(final Consumer<GenericObject> consumer,
+                     final Message<GenericObject> message) {
         try {
             consumer.acknowledge(message);
         } catch (PulsarClientException e) {
@@ -285,8 +288,8 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
         }
     }
 
-    void negativeAcknowledge(final Consumer<KeyValue<GenericRecord, MutationValue>> consumer,
-                             final Message<KeyValue<GenericRecord, MutationValue>> message) {
+    void negativeAcknowledge(final Consumer<GenericObject> consumer,
+                             final Message<GenericObject> message) {
         consumer.negativeAcknowledge(message);
     }
 

--- a/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
+++ b/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
@@ -55,7 +55,7 @@ public class PulsarCassandraSourceTests {
     ).asCompatibleSubstituteFor("cassandra");
 
     public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(
-            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest")
+            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest-272")
     ).asCompatibleSubstituteFor("pulsar");
 
     private static Network testNetwork;


### PR DESCRIPTION
Problem:
with `KeyValue<GenericRecord, MutationValue>` the consume needs to fetch the Schema and if the topic does not exist or it has no schema you will face an error (this is a bug in Pulsar actually)

Changes:
use Schema.AUTO_CONSUME() in order to deal with this problem, the AUTO_CONSUME schema downloads automatically and ondemand, as soon as it handles a message, so the topic may be non existant