### PR TITLE
Add ProducerConfiguration reader from Map<String,Object> and change Source ID  to cassandra-source

### DIFF
--- a/producer-v3-kafka/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
+++ b/producer-v3-kafka/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
@@ -58,7 +58,7 @@ public class Agent {
 
     static void startCdcProducer(String agentArgs) throws IOException {
         log.info("Starting CDC producer agent, cdc_raw_directory={}", DatabaseDescriptor.getCDCLogLocation());
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.KAFKA, agentArgs);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.KAFKA, agentArgs);
 
         OffsetFileWriter offsetFileWriter = new OffsetFileWriter(DatabaseDescriptor.getCDCLogLocation());
         KafkaMutationSender kafkaMutationSender = new KafkaMutationSender(config);

--- a/producer-v3-kafka/src/test/java/com/datastax/cdc/producer/KafkaProducerV3Tests.java
+++ b/producer-v3-kafka/src/test/java/com/datastax/cdc/producer/KafkaProducerV3Tests.java
@@ -152,7 +152,7 @@ public class KafkaProducerV3Tests {
             Thread.sleep(11000);
 
             KafkaConsumer<byte[], GenericRecord> consumer = createConsumer("test-consumer-avro-group");
-            ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.KAFKA, null); // default config
+            ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.KAFKA, null); // default config
             consumer.subscribe(ImmutableList.of(config.topicPrefix + "ks1.table1", config.topicPrefix + "ks1.table2"));
             int noRecordsCount = 0;
 

--- a/producer-v3-pulsar/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
+++ b/producer-v3-pulsar/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
@@ -58,7 +58,7 @@ public class Agent {
 
     static void startCdcProducer(String agentArgs) throws IOException {
         log.info("Starting CDC producer agent, cdc_raw_directory={}", DatabaseDescriptor.getCDCLogLocation());
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.PULSAR, agentArgs);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, agentArgs);
 
         OffsetFileWriter offsetFileWriter = new OffsetFileWriter(DatabaseDescriptor.getCDCLogLocation());
         PulsarMutationSender pulsarMutationSender = new PulsarMutationSender(config);

--- a/producer-v3-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
+++ b/producer-v3-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
@@ -27,7 +27,7 @@ public class PulsarGenericSchemaTests {
 
     @Test
     public void testGenericSchema() {
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.PULSAR, null);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, null);
         PulsarMutationSender pulsarMutationSender = new PulsarMutationSender(config);
 
         RecordSchemaBuilder schemaBuilder = SchemaBuilder.record("testrecord");

--- a/producer-v4-kafka/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
+++ b/producer-v4-kafka/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
@@ -58,7 +58,7 @@ public class Agent {
 
     static void startCdcProducer(String agentArgs) throws IOException {
         log.info("Starting CDC producer agent, cdc_raw_directory={}", DatabaseDescriptor.getCDCLogLocation());
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.KAFKA, agentArgs);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.KAFKA, agentArgs);
 
         OffsetFileWriter offsetFileWriter = new OffsetFileWriter(DatabaseDescriptor.getCDCLogLocation());
         KafkaMutationSender kafkaMutationSender = new KafkaMutationSender(config);

--- a/producer-v4-kafka/src/test/java/com/datastax/cdc/producer/KafkaProducerV4Tests.java
+++ b/producer-v4-kafka/src/test/java/com/datastax/cdc/producer/KafkaProducerV4Tests.java
@@ -148,7 +148,7 @@ public class KafkaProducerV4Tests {
             Thread.sleep(15000);    // wait CL sync on disk
 
             KafkaConsumer<byte[], GenericRecord> consumer = createConsumer("test-consumer-avro-group");
-            ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.KAFKA, null); // default config
+            ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.KAFKA, null); // default config
             consumer.subscribe(ImmutableList.of(config.topicPrefix + "ks1.table1", config.topicPrefix + "ks1.table2"));
             int noRecordsCount = 0;
 

--- a/producer-v4-pulsar/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
+++ b/producer-v4-pulsar/src/main/java/com/datastax/cassandra/cdc/producer/Agent.java
@@ -57,7 +57,7 @@ public class Agent {
 
     static void startCdcProducer(String agentArgs) throws Exception {
         log.info("Starting CDC producer agent, cdc_raw_directory={}", DatabaseDescriptor.getCDCLogLocation());
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.PULSAR, agentArgs);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, agentArgs);
 
         OffsetFileWriter offsetFileWriter = new OffsetFileWriter(DatabaseDescriptor.getCDCLogLocation());
         PulsarMutationSender pulsarMutationSender = new PulsarMutationSender(config);

--- a/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
+++ b/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
@@ -27,7 +27,7 @@ public class PulsarGenericSchemaTests {
 
     @Test
     public void testGenericSchema() {
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, null);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, "");
         PulsarMutationSender pulsarMutationSender = new PulsarMutationSender(config);
 
         RecordSchemaBuilder schemaBuilder = SchemaBuilder.record("testrecord");

--- a/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
+++ b/producer-v4-pulsar/src/test/java/com/datastax/cassandra/cdc/producer/PulsarGenericSchemaTests.java
@@ -16,7 +16,6 @@
 package com.datastax.cassandra.cdc.producer;
 
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -28,7 +27,7 @@ public class PulsarGenericSchemaTests {
 
     @Test
     public void testGenericSchema() {
-        ProducerConfig config = ProducerConfig.create(ProducerConfig.Plateform.PULSAR, null);
+        ProducerConfig config = ProducerConfig.create(ProducerConfig.Platform.PULSAR, null);
         PulsarMutationSender pulsarMutationSender = new PulsarMutationSender(config);
 
         RecordSchemaBuilder schemaBuilder = SchemaBuilder.record("testrecord");

--- a/producer/src/main/java/com/datastax/cassandra/cdc/producer/ProducerConfig.java
+++ b/producer/src/main/java/com/datastax/cassandra/cdc/producer/ProducerConfig.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 @Slf4j
 public class ProducerConfig {
@@ -30,14 +29,14 @@ public class ProducerConfig {
     public static final String CDC_PROPERTY_PREFIX = "cdc.";
     public static final String storageDir = System.getProperty("cassandra.storagedir", null);
 
-    public enum Plateform {
+    public enum Platform {
         ALL, PULSAR, KAFKA;
     }
 
     @AllArgsConstructor
     public static class Setting<T> {
         public final String name;
-        public final Plateform plateform;
+        public final Platform platform;
         public final BiFunction<ProducerConfig, String, T> initializer;
         public final Function<ProducerConfig, T> supplier;
     }
@@ -45,113 +44,113 @@ public class ProducerConfig {
     public static final String CDC_RELOCATION_DIR = "cdcRelocationDir";
     public String cdcRelocationDir = System.getProperty(CDC_PROPERTY_PREFIX + CDC_RELOCATION_DIR, storageDir + File.separator + "cdc_backup");
     public static final Setting<String> CDC_RELOCATION_DIR_SETTING =
-            new Setting<>(CDC_RELOCATION_DIR, Plateform.ALL, (c,s) -> c.cdcRelocationDir = s, c -> c.cdcRelocationDir);
+            new Setting<>(CDC_RELOCATION_DIR, Platform.ALL, (c, s) -> c.cdcRelocationDir = s, c -> c.cdcRelocationDir);
 
     public static final String CDC_DIR_POOL_INTERVAL_MS = "cdcPoolIntervalMs";
     public long cdcDirPollIntervalMs = Long.getLong(CDC_PROPERTY_PREFIX + CDC_DIR_POOL_INTERVAL_MS, 60000L);
     public static final Setting<Long> CDC_DIR_POOL_INTERVAL_MS_SETTING =
-            new Setting<>(CDC_DIR_POOL_INTERVAL_MS, Plateform.ALL, (c,s) -> c.cdcDirPollIntervalMs = Long.parseLong(s), c -> c.cdcDirPollIntervalMs);
+            new Setting<>(CDC_DIR_POOL_INTERVAL_MS, Platform.ALL, (c, s) -> c.cdcDirPollIntervalMs = Long.parseLong(s), c -> c.cdcDirPollIntervalMs);
 
     public static final String ERROR_COMMITLOG_REPROCESS_ENABLED = "errorCommitLogReprocessEnabled";
     public boolean errorCommitLogReprocessEnabled = Boolean.getBoolean(CDC_PROPERTY_PREFIX + ERROR_COMMITLOG_REPROCESS_ENABLED);
     public static final Setting<Boolean> ERROR_COMMITLOG_REPROCESS_ENABLED_SETTING =
-            new Setting<>(ERROR_COMMITLOG_REPROCESS_ENABLED, Plateform.ALL, (c,s) -> c.errorCommitLogReprocessEnabled = Boolean.parseBoolean(s), c -> c.errorCommitLogReprocessEnabled);
+            new Setting<>(ERROR_COMMITLOG_REPROCESS_ENABLED, Platform.ALL, (c, s) -> c.errorCommitLogReprocessEnabled = Boolean.parseBoolean(s), c -> c.errorCommitLogReprocessEnabled);
 
     public static final String EMIT_TOMBSTONE_ON_DELETE = "emitTombstoneOnDelete";
     public boolean emitTombstoneOnDelete = Boolean.getBoolean(CDC_PROPERTY_PREFIX + EMIT_TOMBSTONE_ON_DELETE);
     public static final Setting<Boolean> EMIT_TOMBSTONE_ON_DELETE_SETTING =
-            new Setting<>(EMIT_TOMBSTONE_ON_DELETE, Plateform.ALL, (c,s) -> c.emitTombstoneOnDelete = Boolean.parseBoolean(s), c -> c.emitTombstoneOnDelete);
+            new Setting<>(EMIT_TOMBSTONE_ON_DELETE, Platform.ALL, (c, s) -> c.emitTombstoneOnDelete = Boolean.parseBoolean(s), c -> c.emitTombstoneOnDelete);
 
     public static final String TOPIC_PREFIX = "topicPrefix";
     public String topicPrefix = System.getProperty(CDC_PROPERTY_PREFIX + TOPIC_PREFIX, "events-");
     public static final Setting<String> TOPIC_PREFIX_SETTING =
-            new Setting<>(TOPIC_PREFIX, Plateform.ALL, (c,s) -> c.topicPrefix = s, c -> c.topicPrefix);
+            new Setting<>(TOPIC_PREFIX, Platform.ALL, (c, s) -> c.topicPrefix = s, c -> c.topicPrefix);
 
     public static final String PULSAR_SERVICE_URL = "pulsarServiceUrl";
     public String pulsarServiceUrl = System.getProperty(CDC_PROPERTY_PREFIX + PULSAR_SERVICE_URL, "pulsar://localhost:6650");
     public static final Setting<String> PULSAR_SERVICE_URL_SETTING =
-            new Setting<>(PULSAR_SERVICE_URL, Plateform.PULSAR, (c,s) -> c.pulsarServiceUrl = s, c -> c.pulsarServiceUrl);
+            new Setting<>(PULSAR_SERVICE_URL, Platform.PULSAR, (c, s) -> c.pulsarServiceUrl = s, c -> c.pulsarServiceUrl);
 
     public static final String KAFKA_BROKERS = "kafkaBrokers";
     public String kafkaBrokers = System.getProperty(CDC_PROPERTY_PREFIX + KAFKA_BROKERS, "localhost:9092");
     public static final Setting<String> KAFKA_BROKERS_SETTING =
-            new Setting<>(KAFKA_BROKERS, Plateform.KAFKA, (c,s) -> c.kafkaBrokers = s, c -> c.kafkaBrokers);
+            new Setting<>(KAFKA_BROKERS, Platform.KAFKA, (c, s) -> c.kafkaBrokers = s, c -> c.kafkaBrokers);
 
     public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafkaSchemaRegistryUrl";
     public String kafkaSchemaRegistryUrl = System.getProperty(CDC_PROPERTY_PREFIX + KAFKA_SCHEMA_REGISTRY_URL, "http://localhost:8081");
     public static final Setting<String> KAFKA_SCHEMA_REGISTRY_URL_SETTING =
-            new Setting<>(KAFKA_SCHEMA_REGISTRY_URL, Plateform.KAFKA, (c,s) -> c.kafkaSchemaRegistryUrl = s, c -> c.kafkaSchemaRegistryUrl);
+            new Setting<>(KAFKA_SCHEMA_REGISTRY_URL, Platform.KAFKA, (c, s) -> c.kafkaSchemaRegistryUrl = s, c -> c.kafkaSchemaRegistryUrl);
 
     public static final String SSL_PROVIDER = "sslProvider";
     public String sslProvider = System.getProperty(CDC_PROPERTY_PREFIX + SSL_PROVIDER);
     public static final Setting<String> SSL_PROVIDER_SETTING =
-            new Setting<>(SSL_PROVIDER, Plateform.ALL, (c,s) -> c.sslProvider = s, c -> c.sslProvider);
+            new Setting<>(SSL_PROVIDER, Platform.ALL, (c, s) -> c.sslProvider = s, c -> c.sslProvider);
 
     public static final String SSL_TRUSTSTORE_PATH = "sslTruststorePath";
     public String sslTruststorePath = System.getProperty(CDC_PROPERTY_PREFIX + SSL_TRUSTSTORE_PATH);
     public static final Setting<String> SSL_TRUSTSTORE_PATH_SETTING =
-            new Setting<>(SSL_TRUSTSTORE_PATH, Plateform.ALL, (c,s) -> c.sslTruststorePath = s, c -> c.sslTruststorePath);
+            new Setting<>(SSL_TRUSTSTORE_PATH, Platform.ALL, (c, s) -> c.sslTruststorePath = s, c -> c.sslTruststorePath);
 
     public static final String SSL_TRUSTSTORE_PASSWORD = "sslTruststorePassword";
     public String sslTruststorePassword = System.getProperty(CDC_PROPERTY_PREFIX + SSL_TRUSTSTORE_PASSWORD);
     public static final Setting<String> SSL_TRUSTSTORE_PASSWORD_SETTING =
-            new Setting<>(SSL_TRUSTSTORE_PASSWORD, Plateform.ALL, (c,s) -> c.sslTruststorePassword = s, c -> c.sslTruststorePassword);
+            new Setting<>(SSL_TRUSTSTORE_PASSWORD, Platform.ALL, (c, s) -> c.sslTruststorePassword = s, c -> c.sslTruststorePassword);
 
     public static final String SSL_TRUSTSTORE_TYPE = "sslTruststoreType";
     public String sslTruststoreType = System.getProperty(CDC_PROPERTY_PREFIX + SSL_TRUSTSTORE_TYPE, "JKS");
     public static final Setting<String> SSL_TRUSTSTORE_TYPE_SETTING =
-            new Setting<>(SSL_TRUSTSTORE_TYPE, Plateform.ALL, (c,s) -> c.sslTruststoreType = s, c -> c.sslTruststoreType);
+            new Setting<>(SSL_TRUSTSTORE_TYPE, Platform.ALL, (c, s) -> c.sslTruststoreType = s, c -> c.sslTruststoreType);
 
     public static final String SSL_KEYSTORE_PATH = "sslKeystorePath";
     public String sslKeystorePath = System.getProperty(CDC_PROPERTY_PREFIX + SSL_KEYSTORE_PATH);
     public static final Setting<String> SSL_KEYSTORE_PATH_SETTING =
-            new Setting<>(SSL_KEYSTORE_PATH, Plateform.ALL, (c,s) -> c.sslKeystorePath = s, c -> c.sslKeystorePath);
+            new Setting<>(SSL_KEYSTORE_PATH, Platform.ALL, (c, s) -> c.sslKeystorePath = s, c -> c.sslKeystorePath);
 
     public static final String SSL_KEYSTORE_PASSWORD = "sslKeystorePassword";
     public String sslKeystorePassword = System.getProperty(CDC_PROPERTY_PREFIX + SSL_KEYSTORE_PASSWORD);
     public static final Setting<String> SSL_KEYSTORE_PASSWORD_SETTING =
-            new Setting<>(SSL_KEYSTORE_PASSWORD, Plateform.ALL, (c,s) -> c.sslKeystorePassword = s, c -> c.sslKeystorePassword);
+            new Setting<>(SSL_KEYSTORE_PASSWORD, Platform.ALL, (c, s) -> c.sslKeystorePassword = s, c -> c.sslKeystorePassword);
 
     public static final String SSL_CIPHER_SUITES = "sslCipherSuites";
     public String sslCipherSuites = System.getProperty(CDC_PROPERTY_PREFIX + SSL_CIPHER_SUITES);
     public static final Setting<String> SSL_CIPHER_SUITES_SETTING =
-            new Setting<>(SSL_CIPHER_SUITES, Plateform.ALL, (c,s) -> c.sslCipherSuites = s, c -> c.sslCipherSuites);
+            new Setting<>(SSL_CIPHER_SUITES, Platform.ALL, (c, s) -> c.sslCipherSuites = s, c -> c.sslCipherSuites);
 
     public static final String SSL_ENABLED_PROTOCOLS = "sslEnabledProtocols";
     public String sslEnabledProtocols = System.getProperty(CDC_PROPERTY_PREFIX + SSL_ENABLED_PROTOCOLS, "TLSv1.2,TLSv1.1,TLSv1");
     public static final Setting<String> SSL_ENABLED_PROTOCOLS_SETTING =
-            new Setting<>(SSL_ENABLED_PROTOCOLS, Plateform.ALL, (c,s) -> c.sslEnabledProtocols = s, c -> c.sslEnabledProtocols);
+            new Setting<>(SSL_ENABLED_PROTOCOLS, Platform.ALL, (c, s) -> c.sslEnabledProtocols = s, c -> c.sslEnabledProtocols);
 
     public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "sslEndpointIdentificationAlgorithm";
     public String sslEndpointIdentificationAlgorithm = System.getProperty(CDC_PROPERTY_PREFIX + SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "https");
     public static final Setting<String> SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_SETTING =
-            new Setting<>(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, Plateform.KAFKA, (c,s) -> c.sslEndpointIdentificationAlgorithm = s, c -> c.sslEndpointIdentificationAlgorithm);
+            new Setting<>(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, Platform.KAFKA, (c, s) -> c.sslEndpointIdentificationAlgorithm = s, c -> c.sslEndpointIdentificationAlgorithm);
 
     public static final String SSL_ALLOW_INSECURE_CONNECTION = "sslAllowInsecureConnection";
     public boolean sslAllowInsecureConnection = Boolean.getBoolean(CDC_PROPERTY_PREFIX + SSL_ALLOW_INSECURE_CONNECTION);
     public static final Setting<Boolean> SSL_ALLOW_INSECURE_CONNECTION_SETTING =
-            new Setting<>(SSL_ALLOW_INSECURE_CONNECTION, Plateform.PULSAR, (c,s) -> c.sslAllowInsecureConnection = Boolean.parseBoolean(s), c -> c.sslAllowInsecureConnection);
+            new Setting<>(SSL_ALLOW_INSECURE_CONNECTION, Platform.PULSAR, (c, s) -> c.sslAllowInsecureConnection = Boolean.parseBoolean(s), c -> c.sslAllowInsecureConnection);
 
     public static final String SSL_HOSTNAME_VERIFICATION_ENABLE = "sslHostnameVerificationEnable";
     public boolean sslHostnameVerificationEnable = Boolean.getBoolean(CDC_PROPERTY_PREFIX + SSL_HOSTNAME_VERIFICATION_ENABLE);
     public static final Setting<Boolean> SSL_HOSTNAME_VERIFICATION_ENABLE_SETTING =
-            new Setting<>(SSL_HOSTNAME_VERIFICATION_ENABLE, Plateform.PULSAR, (c,s) -> c.sslHostnameVerificationEnable = Boolean.parseBoolean(s), c -> c.sslHostnameVerificationEnable);
+            new Setting<>(SSL_HOSTNAME_VERIFICATION_ENABLE, Platform.PULSAR, (c, s) -> c.sslHostnameVerificationEnable = Boolean.parseBoolean(s), c -> c.sslHostnameVerificationEnable);
 
     public static final String PULSAR_AUTH_PLUGIN_CLASS_NAME = "pulsarAuthPluginClassName";
     public String pulsarAuthPluginClassName = System.getProperty(CDC_PROPERTY_PREFIX + PULSAR_AUTH_PLUGIN_CLASS_NAME);
     public static final Setting<String> PULSAR_AUTH_PLUGIN_CLASS_NAME_SETTING =
-            new Setting<>(PULSAR_AUTH_PLUGIN_CLASS_NAME, Plateform.PULSAR, (c,s) -> c.pulsarAuthPluginClassName = s, c -> c.pulsarAuthPluginClassName);
+            new Setting<>(PULSAR_AUTH_PLUGIN_CLASS_NAME, Platform.PULSAR, (c, s) -> c.pulsarAuthPluginClassName = s, c -> c.pulsarAuthPluginClassName);
 
     public static final String PULSAR_AUTH_PARAMS = "pulsarAuthParams";
     public String pulsarAuthParams = System.getProperty(CDC_PROPERTY_PREFIX + PULSAR_AUTH_PARAMS);
     public static final Setting<String> PULSAR_AUTH_PARAMS_SETTING =
-            new Setting<>(PULSAR_AUTH_PARAMS, Plateform.PULSAR, (c,s) -> c.pulsarAuthParams = s, c -> c.pulsarAuthParams);
+            new Setting<>(PULSAR_AUTH_PARAMS, Platform.PULSAR, (c, s) -> c.pulsarAuthParams = s, c -> c.pulsarAuthParams);
 
     // generic properties for kafka client
     public static final String KAFKA_PROPERTIES = "kafkaProperties";
     public Map<String, String> kafkaProperties = new HashMap<>();
     public static final Setting<Map<String, String>> KAFKA_PROPERTIES_SETTINGS =
-            new Setting<>(KAFKA_PROPERTIES, Plateform.KAFKA,
+            new Setting<>(KAFKA_PROPERTIES, Platform.KAFKA,
                     (c,s) -> {
                         for (String param : s.split(",")) {
                             int i = param.indexOf("=");
@@ -199,14 +198,14 @@ public class ProducerConfig {
         settingMap = Collections.unmodifiableMap(map);
     }
 
-    public static ProducerConfig create(Plateform plateform, Map<String, Object> tenantConfiguration)
+    public static ProducerConfig create(Platform platform, Map<String, Object> tenantConfiguration)
     {
-        return new ProducerConfig().configure(plateform, tenantConfiguration);
+        return new ProducerConfig().configure(platform, tenantConfiguration);
     }
 
-    public static ProducerConfig create(Plateform plateform, String agentParams)
+    public static ProducerConfig create(Platform platform, String agentParams)
     {
-        return new ProducerConfig().configure(plateform, agentParams);
+        return new ProducerConfig().configure(platform, agentParams);
     }
 
     /**
@@ -214,7 +213,7 @@ public class ProducerConfig {
      *
      * @param agentParameters
      */
-    public ProducerConfig configure(Plateform plateform, String agentParameters) {
+    public ProducerConfig configure(Platform platform, String agentParameters) {
         Map<String, Object> parameters = new HashMap<>();
         if (agentParameters != null) {
             for (String token : agentParameters.split("(?<!\\\\),\\s*")) {
@@ -227,7 +226,7 @@ public class ProducerConfig {
                 }
             }
         }
-        return configure(plateform, parameters);
+        return configure(platform, parameters);
     }
 
     /**
@@ -235,7 +234,7 @@ public class ProducerConfig {
      *
      * @param agentParameters
      */
-    public ProducerConfig configure(Plateform plateform, Map<String, Object> agentParameters) {
+    public ProducerConfig configure(Platform platform, Map<String, Object> agentParameters) {
         if (agentParameters == null) {
             agentParameters = new HashMap<>();
         }
@@ -250,8 +249,8 @@ public class ProducerConfig {
             String value = (String) entry.getValue();
             Setting<?> setting = settingMap.get(key);
             if (setting != null) {
-                if (!setting.plateform.equals(Plateform.ALL) && !setting.plateform.equals(plateform)) {
-                    throw new IllegalArgumentException(String.format("Unsupported parameter '%s' for the %s platform ", key, plateform));
+                if (!setting.platform.equals(Platform.ALL) && !setting.platform.equals(platform)) {
+                    throw new IllegalArgumentException(String.format("Unsupported parameter '%s' for the %s platform ", key, platform));
                 }
                 setting.initializer.apply(this, value);
             } else {
@@ -262,7 +261,7 @@ public class ProducerConfig {
         if (log.isInfoEnabled()) {
             StringBuilder sb = new StringBuilder();
             settings.forEach(s -> {
-                if (s.plateform.equals(Plateform.ALL) || s.plateform.equals(plateform)) {
+                if (s.platform.equals(Platform.ALL) || s.platform.equals(platform)) {
                     if (sb.length() > 0)
                         sb.append(", ");
                     sb.append(s.name).append("=").append(s.supplier.apply(this));

--- a/producer/src/test/java/com/datastax/cassandra/cdc/producer/AgentParametersTest.java
+++ b/producer/src/test/java/com/datastax/cassandra/cdc/producer/AgentParametersTest.java
@@ -17,6 +17,9 @@ package com.datastax.cassandra.cdc.producer;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static com.datastax.cassandra.cdc.producer.ProducerConfig.*;
 
@@ -64,7 +67,8 @@ public class AgentParametersTest {
                 ;
 
         ProducerConfig config = new ProducerConfig();
-        config.configure(Plateform.PULSAR, null);     // test NPE
+        config.configure(Plateform.PULSAR, (String) null);     // test NPE
+        config.configure(Plateform.PULSAR, (Map<String, Object>) null);     // test NPE
         config.configure(Plateform.PULSAR, agentArgs);
         assertCommonConfig(config);
 
@@ -76,6 +80,23 @@ public class AgentParametersTest {
     }
 
     @Test
+    public void testConfigurePulsarFromMap() {
+        Map<String, Object> tenantInfo = new HashMap<>();
+        tenantInfo.put(PULSAR_SERVICE_URL, "pulsar+ssl://mypulsar:6650\\,localhost:6651\\,localhost:6652");
+        tenantInfo.put(PULSAR_AUTH_PLUGIN_CLASS_NAME, "MyAuthPlugin");
+        tenantInfo.put(PULSAR_AUTH_PARAMS, "sdds");
+        tenantInfo.put(SSL_ALLOW_INSECURE_CONNECTION, "true");
+        tenantInfo.put(SSL_HOSTNAME_VERIFICATION_ENABLE, "true");
+
+        ProducerConfig config = ProducerConfig.create(Plateform.PULSAR, tenantInfo);
+        assertEquals("pulsar+ssl://mypulsar:6650,localhost:6651,localhost:6652", config.pulsarServiceUrl);
+
+        // Pulsar Auth
+        assertEquals("MyAuthPlugin", config.pulsarAuthPluginClassName);
+        assertEquals("sdds", config.pulsarAuthParams);
+    }
+
+    @Test
     public void testConfigureKafka() {
         String agentArgs = commonConfig +
                 KAFKA_BROKERS + "=mykafka:9092," +
@@ -84,7 +105,8 @@ public class AgentParametersTest {
                 SSL_ENDPOINT_IDENTIFICATION_ALGORITHM + "=none,";
 
         ProducerConfig config = new ProducerConfig();
-        config.configure(Plateform.KAFKA, null);     // test NPE
+        config.configure(Plateform.KAFKA, (String) null);     // test NPE
+        config.configure(Plateform.KAFKA, (Map<String, Object>) null);     // test NPE
         config.configure(Plateform.KAFKA, agentArgs);
 
         assertCommonConfig(config);

--- a/producer/src/test/java/com/datastax/cassandra/cdc/producer/AgentParametersTest.java
+++ b/producer/src/test/java/com/datastax/cassandra/cdc/producer/AgentParametersTest.java
@@ -67,9 +67,9 @@ public class AgentParametersTest {
                 ;
 
         ProducerConfig config = new ProducerConfig();
-        config.configure(Plateform.PULSAR, (String) null);     // test NPE
-        config.configure(Plateform.PULSAR, (Map<String, Object>) null);     // test NPE
-        config.configure(Plateform.PULSAR, agentArgs);
+        config.configure(Platform.PULSAR, (String) null);     // test NPE
+        config.configure(Platform.PULSAR, (Map<String, Object>) null);     // test NPE
+        config.configure(Platform.PULSAR, agentArgs);
         assertCommonConfig(config);
 
         assertEquals("pulsar+ssl://mypulsar:6650,localhost:6651,localhost:6652", config.pulsarServiceUrl);
@@ -88,7 +88,7 @@ public class AgentParametersTest {
         tenantInfo.put(SSL_ALLOW_INSECURE_CONNECTION, "true");
         tenantInfo.put(SSL_HOSTNAME_VERIFICATION_ENABLE, "true");
 
-        ProducerConfig config = ProducerConfig.create(Plateform.PULSAR, tenantInfo);
+        ProducerConfig config = ProducerConfig.create(Platform.PULSAR, tenantInfo);
         assertEquals("pulsar+ssl://mypulsar:6650,localhost:6651,localhost:6652", config.pulsarServiceUrl);
 
         // Pulsar Auth
@@ -105,9 +105,9 @@ public class AgentParametersTest {
                 SSL_ENDPOINT_IDENTIFICATION_ALGORITHM + "=none,";
 
         ProducerConfig config = new ProducerConfig();
-        config.configure(Plateform.KAFKA, (String) null);     // test NPE
-        config.configure(Plateform.KAFKA, (Map<String, Object>) null);     // test NPE
-        config.configure(Plateform.KAFKA, agentArgs);
+        config.configure(Platform.KAFKA, (String) null);     // test NPE
+        config.configure(Platform.KAFKA, (Map<String, Object>) null);     // test NPE
+        config.configure(Platform.KAFKA, agentArgs);
 
         assertCommonConfig(config);
 

--- a/source-pulsar/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
+++ b/source-pulsar/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
  * and publish rows on the data topic.
  */
 @Connector(
-        name = "cassandra",
+        name = "cassandra-source",
         type = IOType.SOURCE,
         help = "The CassandraSource is used for moving data from Cassandra to Pulsar.",
         configClass = CassandraSourceConfig.class)

--- a/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
+++ b/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
@@ -54,7 +54,7 @@ public class PulsarCassandraSourceTests {
     ).asCompatibleSubstituteFor("cassandra");
 
     public static final DockerImageName PULSAR_IMAGE = DockerImageName.parse(
-            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming-all:latest-272")
+            Optional.ofNullable(System.getenv("PULSAR_IMAGE")).orElse("harbor.sjc.dsinternal.org/pulsar/lunastreaming:latest-272")
     ).asCompatibleSubstituteFor("pulsar");
 
     private static Network testNetwork;

--- a/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
+++ b/source-pulsar/src/test/java/com/datastax/oss/pulsar/source/PulsarCassandraSourceTests.java
@@ -16,7 +16,6 @@
 package com.datastax.oss.pulsar.source;
 
 import com.datastax.oss.cdc.CassandraSourceConnectorConfig;
-import com.datastax.oss.common.sink.config.ContactPointsValidator;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.pulsar.source.converters.AvroConverter;
 import com.datastax.oss.pulsar.source.converters.JsonConverter;


### PR DESCRIPTION
- Change Source id for Pulsar IO  to "cassandra-source"
- Add support for configuring the Producer using a Map<String, Object> in order to allow a better integration with the configuration in Astra DB