### PR TITLE
Asciidoc configuration generator

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'application'
+}
+
+compileTestJava {
+    options.compilerArgs += '-parameters'
+}
+
+dependencies {
+    implementation project(':source')
+    implementation("org.apache.kafka:kafka-clients:${kafkaVersion}")
+    implementation("com.datastax.oss:messaging-connectors-commons-core:${messagingConnectorsCommonsVersion}")
+}
+
+
+

--- a/docs/gradle.properties
+++ b/docs/gradle.properties
@@ -1,0 +1,1 @@
+artifact=docs

--- a/docs/modules/ROOT/pages/cfgCassandraAuth.adoc
+++ b/docs/modules/ROOT/pages/cfgCassandraAuth.adoc
@@ -1,0 +1,47 @@
+= Cassandra Authentication Configuration
+
+== Parameters
+
+[#auth.gssapi.keyTab]
+Kerberos keytab file for GSSAPI provider authentication
++
+Type: string
+Default: ""
+Importance: high
+
+[#auth.gssapi.principal]
+Kerberos principal for GSSAPI provider authentication
++
+Type: string
+Default: ""
+Importance: high
+
+[#auth.gssapi.service]
+SASL service name to use for GSSAPI provider authentication
++
+Type: string
+Default: dse
+Importance: high
+
+[#auth.password]
+Password for PLAIN (username/password) provider authentication
++
+Type: password
+Default: [hidden]
+Importance: high
+
+[#auth.provider]
+Authentication provider
++
+Type: string
+Default: None
+Valid Values: [None, PLAIN, GSSAPI]
+Importance: high
+
+[#auth.username]
+Username for PLAIN (username/password) provider authentication
++
+Type: string
+Default: ""
+Importance: high
+

--- a/docs/modules/ROOT/pages/cfgCassandraSSL.adoc
+++ b/docs/modules/ROOT/pages/cfgCassandraSSL.adoc
@@ -1,78 +1,68 @@
-= SSL encrypted connection
-
-When the cluster has client encryption enabled, configure the SSL keys and certificates for the DataStax Apache® Pulsar Connector.
+= Cassandra SSL/TLS Configuration
 
 == Parameters
 
-[source,language-yaml]
-----
-ssl:
-  provider: None
-  cipherSuites:
-  hostnameValidation: true
-  keystore:
-    password:
-    path:
-  truststore:
-    password:
-    path:
-  openssl:
-    keyCertChain:
-    privateKey:
-----
-
-[#provider]
-provider::
-SSL provider to use, if any.
-Valid choices:
--   None
--   JDK
--   OpenSSL
+[#ssl.cipherSuites]
+The cipher suites to enable
 +
-Defaults to None
+Type: list
+Default: ""
+Importance: high
 
-[#hostnameValidation]
-hostnameValidation:: Whether to validate node hostnames when using SSL.
+[#ssl.hostnameValidation]
+Whether or not to validate node hostnames when using SSL
 +
-Defaults to true
+Type: boolean
+Default: true
+Importance: high
 
-[#cipherSuites]
-cipherSuites:: The cipher suites to enable.
+[#ssl.keystore.password]
+Keystore password
 +
-Defaults to none, resulting in a "minimal quality of service" according to JDK documentation.
+Type: password
+Default: [hidden]
+Importance: high
 
-[#keystore-password]
-keystore: password:: Keystore password.
+[#ssl.keystore.path]
+The path to the keystore file
++
+Type: string
+Default: ""
+Importance: high
 
-[#keystore-path]
-keystore: path:: Path to the keystore file.
+[#ssl.openssl.keyCertChain]
+The path to the certificate chain file
++
+Type: string
+Default: ""
+Importance: high
 
-[#openssl-keycertchain]
-openssl: keyCertChain:: Path to the SSL certificate file, when using OpenSSL.
+[#ssl.openssl.privateKey]
+The path to the private key file
++
+Type: string
+Default: ""
+Importance: high
 
-[#openssl-privatekey]
-openssl: privateKey:: Path to the private key file, when using OpenSSL.
+[#ssl.provider]
+SSL/TLS provider
++
+Type: string
+Default: None
+Valid Values: [None, JDK, OpenSSL]
+Importance: high
 
-[#truststore-password]
-truststore: password:: Truststore password.
+[#ssl.truststore.password]
+Truststore password
++
+Type: password
+Default: [hidden]
+Importance: high
 
-[#trustore-path]
-truststore: path:: Path to the truststore file.
+[#ssl.truststore.path]
+The path to the truststore file
++
+Type: string
+Default: ""
+Importance: high
 
-
-== Using a base64 encoded file
-
-For `keystore.path`, `truststore.path`, `openssl.privateKey`, and `openssl.keyCertChain` you can encode the target file using the standard base64 tool, include it directly in the Pulsar configuration file, and the Pulsar function framework will take care of deploying it to additional Pulsar machines:
-
-[source,language-bash]
-----
-base64 -i trust-store-key
-----
-
-Add the output of the command to `truststore: path:`:
-
-[source,language-yaml]
-----
-truststore:
-  path: base64:UEsDBBQACAAIADmJJ1IAAAAAAAAAAAAAAAAGAAkAY2EuY3J0VVQFAAFeQPdfZJTJjvI4HMTveYq5t0bZoTl8Bzt2giEOOGQh3Mi+sgVw4qcf0a25zPj2L0s/VUml+vvzIHaI95eF/YDYxAIB/lElSgi2kGWBt1UBTiCoiAUvIUcs2WyvJ1K/Mw8w7EIGeHVmkyXABlZeBEESgD4KJMpGbrEERYwRzDeIBTikkDhADTGcqBtq9it3cMW0qc4GPOEA7H8B18DCfi3ljh3kjm1QZnAEfkAu5hFKnZV6QvaeYuUHBibPSTT8OsWblmqbJgm6pzfQWaKNo......
-----

--- a/docs/modules/ROOT/pages/cfgCassandraSource.adoc
+++ b/docs/modules/ROOT/pages/cfgCassandraSource.adoc
@@ -1,0 +1,198 @@
+= Cassandra Source Connector Configuration
+
+== Parameters
+
+[#events.topic]
+The topic name to listen cassandra mutation events to
++
+Type: string
+Importance: high
+
+[#key.converter]
+Converter class used to write the message key to the data topic
++
+Type: class
+Importance: high
+
+[#keyspace]
+Cassandra keyspace name
++
+Type: string
+Importance: high
+
+[#table]
+Cassandra table name
++
+Type: string
+Importance: high
+
+[#value.converter]
+Converter class used to write the message value to the data topic
++
+Type: class
+Importance: high
+
+[#cloud.secureConnectBundle]
+The location of the cloud secure bundle used to connect to Datastax Apache Cassandra as a service.
++
+Type: string
+Default: ""
+Importance: high
+
+[#compression]
+Compression algorithm to use when issuing requests to the database server
++
+Type: string
+Default: None
+Valid Values: (case insensitive) [LZ4, NONE, SNAPPY]
+Importance: high
+
+[#connectionPoolLocalSize]
+Number of connections that driver maintains within a connection pool to each node in local dc
++
+Type: int
+Default: 4
+Valid Values: [1,...]
+Importance: high
+
+[#contactPoints]
+Initial contact points
++
+Type: list
+Default: ""
+Importance: high
+
+[#data.topic]
+The topic name to publish cassandra data to
++
+Type: string
+Default: data-topic
+Importance: high
+
+[#ignoreErrors]
+Specifies which errors the connector should ignore when processing the record. Valid values are: None (never ignore errors), All (ignore all errors), Driver (ignore driver errors only, i.e. errors when writing to the database).
++
+Type: string
+Default: None
+Importance: high
+
+[#jmx]
+Whether to enable JMX reporting
++
+Type: boolean
+Default: true
+Importance: high
+
+[#loadBalancing.localDc]
+The datacenter name (commonly dc1, dc2, etc.) local to the machine on which the connector is running
++
+Type: string
+Default: ""
+Importance: high
+
+[#maxConcurrentRequests]
+The maximum number of requests to send at once
++
+Type: int
+Default: 500
+Valid Values: [1,...]
+Importance: high
+
+[#maxNumberOfRecordsInBatch]
+Maximum number of records that could be send in one batch request
++
+Type: int
+Default: 32
+Valid Values: [1,...]
+Importance: high
+
+[#metricsHighestLatency]
+This is used to scale internal data structures for gathering metrics. It should be higher than queryExecutionTimeout. This parameter should be expressed in seconds.
++
+Type: int
+Default: 35
+Valid Values: [1,...]
+Importance: high
+
+[#port]
+Port to connect to nodes
++
+Type: int
+Default: 9042
+Valid Values: [1,...]
+Importance: high
+
+[#queryExecutionTimeout]
+CQL statement execution timeout, in seconds
++
+Type: int
+Default: 30
+Valid Values: [1,...]
+Importance: high
+
+[#columns]
+Regular expression of the Cassandra replicated column names
++
+Type: string
+Default: .*
+Importance: low
+
+[#jmxConnectorDomain]
+Domain for JMX reporting
++
+Type: string
+Default: com.datastax.oss.cdc
+Importance: low
+
+[#events.subscription.name]
+The pulsar events topic subscription name, with a default set to 'sub'
++
+Type: string
+Default: sub
+Importance: high
+
+[#cache.max.digest]
+The maximum number of digest per mutation cache entry, with a default set to 3
++
+Type: long
+Default: 3
+Valid Values: [1,...]
+Importance: high
+
+[#cache.max.capacity]
+The maximum capacity of the mutation cache, with a default size of 32767
++
+Type: long
+Default: 32767
+Valid Values: [1,...]
+Importance: high
+
+[#cache.expire.after.ms]
+The mutation cache entry duration in milliseconds, with a default value of 60 seconds.
++
+Type: long
+Default: 600000
+Valid Values: [1000,...]
+Importance: high
+
+[#cache.only_if_coordinator_match]
+Cache the mutation digest only if the coordinator node is the originator node.
++
+Type: boolean
+Default: true
+Importance: high
+
+[#bootstrap.servers]
+Kafka bootstrap servers
++
+Type: string
+Default: localhost:9092
+Importance: high
+
+[#schema.registry.url]
+Schema registry URL
++
+Type: string
+Default: http://localhost:8081
+Importance: high
+

--- a/docs/src/main/java/org/apache/kafka/common/config/AsciiDocGenerator.java
+++ b/docs/src/main/java/org/apache/kafka/common/config/AsciiDocGenerator.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.config;
+
+import com.datastax.oss.cdc.CassandraSourceConnectorConfig;
+import com.datastax.oss.common.sink.config.AuthenticatorConfig;
+import com.datastax.oss.common.sink.config.SslConfig;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class AsciiDocGenerator {
+
+    public String toAscidoc(ConfigDef configDef) {
+        StringBuilder b = new StringBuilder();
+        for (ConfigDef.ConfigKey key : sortedConfigs(configDef)) {
+            if (key.internalConfig) {
+                continue;
+            }
+            getConfigKeyAsciiDoc(configDef, key, b);
+            b.append("\n");
+        }
+        return b.toString();
+    }
+
+    private void getConfigKeyAsciiDoc(ConfigDef configDef, ConfigDef.ConfigKey key, StringBuilder b) {
+        b.append("[#").append(key.name).append("]").append("\n");
+        for (String docLine : key.documentation.split("\n")) {
+            if (docLine.length() == 0) {
+                continue;
+            }
+            b.append(docLine).append("\n+\n");
+        }
+        b.append("Type: ").append(configDef.getConfigValue(key, "Type")).append("\n");
+        if (key.hasDefault()) {
+            b.append("Default: ").append(configDef.getConfigValue(key, "Default")).append("\n");
+        }
+        if (key.validator != null) {
+            b.append("Valid Values: ").append(configDef.getConfigValue(key, "Valid Values")).append("\n");
+        }
+        b.append("Importance: ").append(configDef.getConfigValue(key, "Importance")).append("\n");
+    }
+
+    private List<ConfigDef.ConfigKey> sortedConfigs(ConfigDef configDef) {
+        final Map<String, Integer> groupOrd = new HashMap<>(configDef.groups().size());
+        int ord = 0;
+        for (String group: configDef.groups()) {
+            groupOrd.put(group, ord++);
+        }
+
+        List<ConfigDef.ConfigKey> configs = new ArrayList<>(configDef.configKeys().values());
+        Collections.sort(configs, (k1, k2) -> compare(k1, k2, groupOrd));
+        return configs;
+    }
+
+    private int compare(ConfigDef.ConfigKey k1, ConfigDef.ConfigKey k2, Map<String, Integer> groupOrd) {
+        int cmp = k1.group == null
+                ? (k2.group == null ? 0 : -1)
+                : (k2.group == null ? 1 : Integer.compare(groupOrd.get(k1.group), groupOrd.get(k2.group)));
+        if (cmp == 0) {
+            cmp = Integer.compare(k1.orderInGroup, k2.orderInGroup);
+            if (cmp == 0) {
+                // first take anything with no default value
+                if (!k1.hasDefault() && k2.hasDefault())
+                    cmp = -1;
+                else if (!k2.hasDefault() && k1.hasDefault())
+                    cmp = 1;
+                else {
+                    cmp = k1.importance.compareTo(k2.importance);
+                    if (cmp == 0)
+                        return k1.name.compareTo(k2.name);
+                }
+            }
+        }
+        return cmp;
+    }
+
+    public void generateConfigDefDoc(Path path, String name, String title, ConfigDef configDef) throws IOException {
+        try (FileWriter fileWriter = new FileWriter(path.resolve(name).toFile())) {
+            PrintWriter pw = new PrintWriter(fileWriter);
+            pw.append("= ").append(title).append("\n\n");
+            pw.append("== Parameters").append("\n\n");
+            pw.append(toAscidoc(configDef));
+            pw.flush();
+        }
+    }
+
+    public void generateCassourceSourceDocs(String outputDir) throws IOException {
+        generateConfigDefDoc(Paths.get(outputDir),
+                "cfgCassandraSource.adoc",
+                "Cassandra Source Connector Configuration",
+                CassandraSourceConnectorConfig.GLOBAL_CONFIG_DEF);
+
+        generateConfigDefDoc(Paths.get(outputDir),
+                "cfgCassandraAuth.adoc",
+                "Cassandra Authentication Configuration",
+                AuthenticatorConfig.CONFIG_DEF);
+
+        generateConfigDefDoc(Paths.get(outputDir),
+                "cfgCassandraSsl.adoc",
+                "Cassandra SSL/TLS Configuration",
+                SslConfig.CONFIG_DEF);
+    }
+
+    public static void main(String[] args) {
+        try {
+            AsciiDocGenerator asciiDocGenerator = new AsciiDocGenerator();
+            asciiDocGenerator.generateCassourceSourceDocs("docs/modules/ROOT/pages");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ vavrVersion=0.10.3
 testContainersVersion=1.15.3
 caffeineVersion=2.8.8
 guavaVersion=30.1-jre
-messagingConnectorsCommonsVersion=1.0.12
+messagingConnectorsCommonsVersion=1.0.13-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,4 +27,5 @@ include 'producer-v3-kafka'
 include 'producer-v4-kafka'
 include 'source-kafka'
 include 'distribution'
+include 'docs'
 

--- a/source/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
+++ b/source/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
@@ -143,7 +143,8 @@ public class CassandraSourceConnectorConfig {
                             ConfigDef.Type.STRING,
                             "sub",
                             ConfigDef.Importance.HIGH,
-                            "The pulsar events topic subscription name, with a default set to 'sub'")
+                            "The pulsar events topic subscription name, with a default set to 'sub'",
+                            "Pulsar only", 1, ConfigDef.Width.NONE, "SubscriptionName")
                     .define(DATA_TOPIC_NAME_CONFIG,
                             ConfigDef.Type.STRING,
                             "data-topic",
@@ -152,23 +153,30 @@ public class CassandraSourceConnectorConfig {
                     .define(CACHE_MAX_DIGESTS_CONFIG,
                             ConfigDef.Type.LONG,
                             "3",
+                            ConfigDef.Range.atLeast(1),
                             ConfigDef.Importance.HIGH,
-                            "The maximum number of digest per mutation cache entry, with a default set to 3")
+                            "The maximum number of digest per mutation cache entry, with a default set to 3",
+                            "CQL Read cache", 1, ConfigDef.Width.NONE, "CacheMaxDigest")
+                    .define(CACHE_MAX_CAPACITY_CONFIG,
+                            ConfigDef.Type.LONG,
+                            "32767",
+                            ConfigDef.Range.atLeast(1),
+                            ConfigDef.Importance.HIGH,
+                            "The maximum capacity of the mutation cache, with a default size of 32767",
+                            "CQL Read cache", 2, ConfigDef.Width.NONE, "CacheMaxDigest")
+                    .define(CACHE_EXPIRE_AFTER_MS_CONFIG,
+                            ConfigDef.Type.LONG,
+                            "600000",
+                            ConfigDef.Range.atLeast(1000),
+                            ConfigDef.Importance.HIGH,
+                            "The mutation cache entry duration in milliseconds, with a default value of 60 seconds.",
+                            "CQL Read cache", 3, ConfigDef.Width.NONE, "CacheExpireAfter")
                     .define(CACHE_ONLY_IF_COORDINATOR_MATCH,
                             ConfigDef.Type.BOOLEAN,
                             "true",
                             ConfigDef.Importance.HIGH,
-                            "Cache the mutation digest only if the coordinator node is the originator node.")
-                    .define(CACHE_MAX_CAPACITY_CONFIG,
-                            ConfigDef.Type.LONG,
-                            "32767",
-                            ConfigDef.Importance.HIGH,
-                            "The maximum capacity of the mutation cache, with a default size of 32767")
-                    .define(CACHE_EXPIRE_AFTER_MS_CONFIG,
-                            ConfigDef.Type.LONG,
-                            "600000",
-                            ConfigDef.Importance.HIGH,
-                            "The mutation cache entry duration in milliseconds, with a default value of 60 seconds.")
+                            "Cache the mutation digest only if the coordinator node is the originator node.",
+                            "CQL Read cache", 4, ConfigDef.Width.NONE, "CacheExpireAfter")
                     .define(KEY_CONVERTER_CLASS_CONFIG,
                             ConfigDef.Type.CLASS,
                             ConfigDef.Importance.HIGH,
@@ -181,12 +189,14 @@ public class CassandraSourceConnectorConfig {
                             ConfigDef.Type.STRING,
                             "localhost:9092",
                             ConfigDef.Importance.HIGH,
-                            "Kafka bootstrap servers")
+                            "Kafka bootstrap servers",
+                            "Kafka only", 1, ConfigDef.Width.NONE, "BootstrapServers")
                     .define(SCHEMA_REGISTRY_URL_CONFIG,
                             ConfigDef.Type.STRING,
                             "http://localhost:8081",
                             ConfigDef.Importance.HIGH,
-                            "Schema registry URL")
+                            "Schema registry URL",
+                            "Kafka only", 2, ConfigDef.Width.NONE, "SchemaRegistryUrl")
                     .define(
                             CassandraSinkConfig.CONTACT_POINTS_OPT,
                             ConfigDef.Type.LIST,
@@ -229,8 +239,9 @@ public class CassandraSourceConnectorConfig {
                             COMPRESSION_OPT,
                             ConfigDef.Type.STRING,
                             "None",
+                            ConfigDef.CaseInsensitiveValidString.in("NONE", "LZ4", "SNAPPY"),
                             ConfigDef.Importance.HIGH,
-                            "None | LZ4 | Snappy")
+                            "Compression algorithm to use when issuing requests to the database server")
                     .define(
                             QUERY_EXECUTION_TIMEOUT_OPT,
                             ConfigDef.Type.INT,

--- a/source/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
+++ b/source/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
@@ -213,7 +213,7 @@ class CassandraSourceConnectorConfigTest {
                 .isInstanceOf(ConfigException.class)
                 .hasMessageContaining(
                         String.format(
-                                "Invalid value foo for configuration %s: valid values are none, snappy, lz4",
+                                "Invalid value foo for configuration %s: String must be one of (case insensitive): LZ4, NONE, SNAPPY",
                                 COMPRESSION_OPT));
     }
 


### PR DESCRIPTION
The Kafka ConfigDef class already has methods to generate HTML or RST documentation. The ASCIIDOC generator is derived from that code and produce the documentation page for the connector configuration (see docs/modules/ROOT/pages)