### PR TITLE
DOC-5707, DOC-5708 remove, update attributes

### DIFF
--- a/docs/local-preview-playbook.yml
+++ b/docs/local-preview-playbook.yml
@@ -67,7 +67,7 @@ asciidoc:
     astra-ui: 'Astra Portal'
     astra-url: 'https://astra.datastax.com'
     astra-ui-link: '{astra-url}[{astra-ui}^]'
-    db-classic: 'Managed Cluster'
+    db-classic: 'Astra Managed Clusters'
     db-serverless: 'Serverless (non-vector)'
     db-serverless-vector: 'Serverless (vector)'
     scb: 'Secure Connect Bundle (SCB)'
@@ -217,10 +217,6 @@ asciidoc:
     capacity-service: 'Capacity Service'
     lcm: 'Lifecycle Manager (LCM)'
     lcm-short: 'LCM'
-    cr: 'custom resource (CR)'
-    cr-short: 'CR'
-    crd: 'custom resource definition (CRD)'
-    crd-short: 'CRD'
     # Antora Atlas
     primary-site-url: https://docs.datastax.com/en
     primary-site-manifest-url: https://docs.datastax.com/en/site-manifest.json

--- a/docs/modules/ROOT/pages/cdc-concepts.adoc
+++ b/docs/modules/ROOT/pages/cdc-concepts.adoc
@@ -191,7 +191,7 @@ Once the initial topic schema has been set, an ideal path has been established t
 
 Inevitably, table designs change: Columns are added, updated, or removed.
 When these changes occur, the components that are part of the CDC flow must adapt to preserve the ideal path of event data.
-This can become quite a complex set of decisions and as such, there are specific changes a CDC flow can tolerate before the flow needs to be recreated entirely.
+This can become quite a complex set of decisions and as such, there are specific changes a CDC flow can tolerate before the flow needs to be re-created entirely.
 
 Here is a summary of how the data message schema is created:
 


### PR DESCRIPTION
- Remove obsolete attributes from local preview playbook
- Update db-classic attribute definition in local preview playbook

None of these attributes are actually used in this docset.

- Change recreate to re-create